### PR TITLE
Fix the proxy authentication on the Request helper method

### DIFF
--- a/app/Classes/Helper.php
+++ b/app/Classes/Helper.php
@@ -102,7 +102,7 @@ class Helper
         }
 
         if (env('PROXY_USER')) {
-            curl_setopt($ch, CURLOPT_PROXYUSERPWD, env('PROXY_USER').':'.env('PROXY_USER'));
+            curl_setopt($ch, CURLOPT_PROXYUSERPWD, env('PROXY_USER').':'.env('PROXY_PASS'));
         }
 
         if (!is_null($postFields)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Fix for proxy environment

This fix allows the use of the Request method helper on Proxy Environment. There was an error when using the user proxy credentials.
